### PR TITLE
Improved Unmarshalling Robustness

### DIFF
--- a/internal/dnshelper/dns.go
+++ b/internal/dnshelper/dns.go
@@ -308,7 +308,14 @@ func unmarshallRecord(ctx context.Context, input []byte) (*Record, error) {
 		return nil, fmt.Errorf("empty json document")
 	}
 
-	err = json.Unmarshal(input, &records)
+	startIdx := bytes.IndexAny(t, "[{")
+	if startIdx == -1 {
+	return nil, fmt.Errorf("no JSON object found in input")
+	}
+
+	jsonStart := t[startIdx:]
+
+	err = json.Unmarshal(jsonStart, &records)
 	if err != nil {
 		tflog.Debug(ctx, fmt.Sprintf("Failed to unmarshall an DNSRecord json document with error %q, document was %s", err, string(input)))
 		return nil, fmt.Errorf("failed while unmarshalling DNSRecord json document: %s", err)

--- a/internal/dnshelper/dns.go
+++ b/internal/dnshelper/dns.go
@@ -310,7 +310,7 @@ func unmarshallRecord(ctx context.Context, input []byte) (*Record, error) {
 
 	startIdx := bytes.IndexAny(t, "[{")
 	if startIdx == -1 {
-	return nil, fmt.Errorf("no JSON object found in input")
+		return nil, fmt.Errorf("no JSON object found in input")
 	}
 
 	jsonStart := t[startIdx:]


### PR DESCRIPTION
Sometimes stdout can include garbage ahead of the JSON we want to parse. The unmarshalling function should ignore this garbage and instead look for the first valid JSON character. 